### PR TITLE
fix maxrows error

### DIFF
--- a/gpdvega/geodata.py
+++ b/gpdvega/geodata.py
@@ -80,7 +80,7 @@ def gpd_to_json(data):
 
 alt.data_transformers.register(
     'gpd_to_values',
-    lambda data: alt.pipe(data, alt.limit_rows, gpd_to_values)
+    lambda data: alt.pipe(data, gpd_to_values)
 )
 alt.data_transformers.register(
     'gpd_to_json',


### PR DESCRIPTION
The maxrows error will still come with this current configuration.
I had to take out alt.limit_rows.
After doing that, I can plot large geographic plots.